### PR TITLE
Check the completed task again

### DIFF
--- a/test_mcp.py
+++ b/test_mcp.py
@@ -70,6 +70,21 @@ async def test_mcp_server():
                 print(f"  ✅ Correctly failed with error: {e}")
             
             print()
+            
+            # Test the test_slack tool
+            print("🔍 Testing test_slack tool")
+            try:
+                result = await session.call_tool("test_slack", {})
+                
+                if result.content:
+                    print(f"  ✅ Success! Response: {result.content[0].text}")
+                else:
+                    print("  ❌ No content returned")
+                    
+            except Exception as e:
+                print(f"  ❌ Error: {e}")
+            
+            print()
             print("🎉 All tests completed!")
 
 if __name__ == "__main__":


### PR DESCRIPTION
A new `test_slack` tool was implemented and integrated into the MCP server.

*   In `sse-server.py`, `handle_list_tools()` was updated to register `test_slack` with a "Test Slack integration" description.
*   The `handle_call_tool()` function was modified to include logic for `test_slack`, returning "bingo!" when called. The existing `get_tasklist` logic was refactored for clarity.
*   The `test_slack` tool was added to the `tools_data` arrays in the root (`/`), SSE (`/mcp/sse`), and MCP (`/mcp`) HTTP endpoints for discoverability.
*   `test_mcp.py` was updated with a new test case to verify the `test_slack` tool's functionality via the MCP protocol.
*   Project dependencies were streamlined: `pyproject.toml` and `uv.lock` were modified to remove the `cli` extra from `mcp` and prune several unused packages (e.g., `markdown-it-py`, `rich`, `typer`), simplifying the environment.
*   The `mcp-server.py` file was removed, consolidating server logic into `sse-server.py`.